### PR TITLE
docs: align README with current project state

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,75 @@
-# AgentRAG — Modular RAG pipeline for AI agents. Chunking, embedding, retrieval, and reranking with pluggable vector stores. Built for agenic workflows
+# AgentRAG
 
-Modular RAG pipeline for AI agents. Chunking, embedding, retrieval, and reranking with pluggable vector stores. Built for agenic workflows.
+AgentRAG is an early-stage project for building modular retrieval-augmented generation pipelines for AI agents, with a focus on chunking, embedding, retrieval, reranking, and pluggable vector-store workflows.
+
+RAG systems often start simple and become messy quickly. Chunking strategies, embedding providers, retrievers, rerankers, and vector stores all evolve at different speeds, especially once they are used inside agent workflows rather than a single chatbot. AgentRAG exists to make that stack easier to reason about and easier to compose.
 
 ## Why AgentRAG
 
-AgentRAG exists to make this workflow practical. Modular rag pipeline for ai agents. chunking, embedding, retrieval, and reranking with pluggable vector stores. built for agenic workflows. It favours a small, inspectable surface over sprawling configuration.
+The goal is to make RAG pipelines more modular and more practical for agent systems.
 
-## How It Works
+That means:
 
-The code is organised as a focused, single-purpose module with a clear entry point and minimal ceremony.
+- separating retrieval stages cleanly
+- supporting experimentation without forcing a full framework
+- making it easier to compare chunking, embedding, and retrieval choices
+- building toward reusable patterns for agent-oriented retrieval workflows
 
-## Getting Started
+## Current Status
 
-Clone the repository and inspect the source to see how to run it.
+AgentRAG is currently at an early public stage.
 
-## Usage
+The repository is still minimal, and this README mainly documents the project direction. As implementation work lands, this repo will evolve into a more concrete toolkit with runnable components, examples, and integration patterns.
 
-See the source files and entry points for concrete usage patterns.
+## Project Direction
+
+AgentRAG is intended to explore and eventually support:
+
+- pluggable chunking strategies
+- embedding-provider abstraction
+- interchangeable vector stores
+- reranking and retrieval-stage composition
+- retrieval patterns designed for agentic workflows instead of one-shot search
+
+## What I Want This Repo To Become
+
+Over time, AgentRAG should become a practical home for:
+
+- reusable retrieval pipeline building blocks
+- experiments that compare retrieval strategies side by side
+- examples for agent-aware context assembly
+- cleaner interfaces between indexing, retrieval, and reranking
+- developer-friendly patterns for production RAG systems
+
+## Why This Matters
+
+RAG is no longer just about search quality. In agent systems, retrieval affects planning, tool use, context quality, and overall reliability. A modular retrieval layer makes it easier to improve those systems without rewriting everything around them.
+
+## Roadmap
+
+Near-term priorities include:
+
+- establishing the first code structure
+- defining the core retrieval pipeline interfaces
+- adding example workflows for indexing and retrieval
+- documenting integration patterns for agent runtimes
+- building toward more realistic retrieval experiments
+
+## Contributing
+
+Contributions, ideas, and feedback are welcome, especially around:
+
+- chunking strategies
+- embeddings and retrieval abstractions
+- reranking patterns
+- vector-store integration design
+- documentation and examples
 
 ## Project Structure
 
-```
+```text
 AgentRAG/
-├── README.md
+└── README.md
 ```
+
+The repository is intentionally minimal right now while the initial implementation direction is being defined.


### PR DESCRIPTION
## Summary
- replace placeholder README copy with a clearer early-stage project overview
- fix typos and improve the positioning around modular RAG workflows
- document current status honestly while keeping the roadmap clear
