### PR TITLE
feat: scaffold core RAG pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ That means:
 
 ## Current Status
 
-AgentRAG is currently at an early public stage.
+AgentRAG is now at the first runnable implementation stage.
 
-The repository is still minimal, and this README mainly documents the project direction. As implementation work lands, this repo will evolve into a more concrete toolkit with runnable components, examples, and integration patterns.
+The repository includes a small Python package with core RAG pipeline interfaces plus an in-memory reference pipeline for indexing and retrieval. The goal is still to keep the surface area small while making the architecture concrete enough to extend.
 
 ## Project Direction
 
@@ -49,11 +49,38 @@ RAG is no longer just about search quality. In agent systems, retrieval affects 
 
 Near-term priorities include:
 
-- establishing the first code structure
-- defining the core retrieval pipeline interfaces
-- adding example workflows for indexing and retrieval
 - documenting integration patterns for agent runtimes
 - building toward more realistic retrieval experiments
+
+## Reference Implementation
+
+The first working implementation now includes:
+
+- `Document`, `Chunk`, `IndexedChunk`, and `SearchResult` models
+- protocol-style interfaces for `Chunker`, `Embedder`, `VectorStore`, and `Retriever`
+- `SimpleWordChunker` for local chunking experiments
+- `BagOfWordsEmbedder` for deterministic local embeddings
+- `InMemoryVectorStore` plus `InMemoryRAGPipeline` for end-to-end indexing and retrieval
+
+### Example
+
+```python
+from agentrag import Document, InMemoryRAGPipeline
+
+pipeline = InMemoryRAGPipeline()
+pipeline.index_documents(
+    [
+        Document(
+            id="doc-1",
+            text="Ganapathi homam is performed before major life events to remove obstacles.",
+        )
+    ]
+)
+
+response = pipeline.retrieve("Which ritual helps remove obstacles?", top_k=1)
+for result in response.results:
+    print(result.chunk.document_id, result.score, result.chunk.text)
+```
 
 ## Contributing
 
@@ -69,7 +96,17 @@ Contributions, ideas, and feedback are welcome, especially around:
 
 ```text
 AgentRAG/
-└── README.md
+├── README.md
+├── pyproject.toml
+├── src/agentrag/
+└── tests/
 ```
 
-The repository is intentionally minimal right now while the initial implementation direction is being defined.
+## Getting Started
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -e .
+pytest
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,21 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "agentrag"
+version = "0.1.0"
+description = "Modular retrieval-augmented generation pipeline primitives for agent workflows."
+readme = "README.md"
+requires-python = ">=3.10"
+dependencies = []
+
+[tool.setuptools]
+package-dir = {"" = "src"}
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.pytest.ini_options]
+pythonpath = ["src"]
+testpaths = ["tests"]

--- a/src/agentrag/__init__.py
+++ b/src/agentrag/__init__.py
@@ -1,0 +1,26 @@
+"""AgentRAG package exports."""
+
+from agentrag.interfaces import (
+    Chunk,
+    Chunker,
+    Document,
+    Embedder,
+    IndexedChunk,
+    Retriever,
+    SearchResult,
+    VectorStore,
+)
+from agentrag.pipeline import InMemoryRAGPipeline, RetrievalResponse
+
+__all__ = [
+    "Chunk",
+    "Chunker",
+    "Document",
+    "Embedder",
+    "IndexedChunk",
+    "InMemoryRAGPipeline",
+    "Retriever",
+    "RetrievalResponse",
+    "SearchResult",
+    "VectorStore",
+]

--- a/src/agentrag/interfaces.py
+++ b/src/agentrag/interfaces.py
@@ -1,0 +1,55 @@
+"""Core RAG pipeline interfaces and shared models."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Protocol
+
+
+@dataclass(slots=True)
+class Document:
+    id: str
+    text: str
+    metadata: dict[str, str] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class Chunk:
+    id: str
+    document_id: str
+    text: str
+    metadata: dict[str, str] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class IndexedChunk(Chunk):
+    embedding: list[float] = field(default_factory=list)
+
+
+@dataclass(slots=True)
+class SearchResult:
+    chunk: Chunk
+    score: float
+
+
+class Chunker(Protocol):
+    def chunk(self, document: Document) -> list[Chunk]:
+        """Split a document into chunks."""
+
+
+class Embedder(Protocol):
+    def embed(self, texts: list[str]) -> list[list[float]]:
+        """Embed a list of strings."""
+
+
+class VectorStore(Protocol):
+    def upsert(self, chunks: list[IndexedChunk]) -> None:
+        """Persist indexed chunks."""
+
+    def search(self, query_embedding: list[float], top_k: int) -> list[SearchResult]:
+        """Return the nearest chunks for the query embedding."""
+
+
+class Retriever(Protocol):
+    def retrieve(self, query: str, top_k: int = 5) -> list[SearchResult]:
+        """Retrieve the most relevant chunks for a query."""

--- a/src/agentrag/pipeline.py
+++ b/src/agentrag/pipeline.py
@@ -1,0 +1,165 @@
+"""Reference in-memory indexing and retrieval pipeline."""
+
+from __future__ import annotations
+
+import math
+import re
+from collections import Counter
+from dataclasses import dataclass
+
+from agentrag.interfaces import Chunk, Chunker, Document, Embedder, IndexedChunk, SearchResult, VectorStore
+
+
+def _tokenize(text: str) -> list[str]:
+    return re.findall(r"\w+", text.lower())
+
+
+class SimpleWordChunker:
+    """Chunk documents into fixed-size word windows."""
+
+    def __init__(self, chunk_size: int = 80, overlap: int = 10) -> None:
+        if chunk_size <= 0:
+            raise ValueError("chunk_size must be positive")
+        if overlap < 0 or overlap >= chunk_size:
+            raise ValueError("overlap must be non-negative and smaller than chunk_size")
+        self.chunk_size = chunk_size
+        self.overlap = overlap
+
+    def chunk(self, document: Document) -> list[Chunk]:
+        words = document.text.split()
+        if not words:
+            return []
+
+        step = self.chunk_size - self.overlap
+        chunks: list[Chunk] = []
+        for index, start in enumerate(range(0, len(words), step)):
+            window = words[start : start + self.chunk_size]
+            if not window:
+                continue
+            chunks.append(
+                Chunk(
+                    id=f"{document.id}-chunk-{index}",
+                    document_id=document.id,
+                    text=" ".join(window),
+                    metadata={
+                        **document.metadata,
+                        "chunk_index": str(index),
+                        "start_word": str(start),
+                    },
+                )
+            )
+            if start + self.chunk_size >= len(words):
+                break
+        return chunks
+
+
+class BagOfWordsEmbedder:
+    """Tiny deterministic embedder for local tests and reference workflows."""
+
+    def __init__(self) -> None:
+        self._vocabulary: dict[str, int] = {}
+
+    def embed(self, texts: list[str]) -> list[list[float]]:
+        for text in texts:
+            for token in _tokenize(text):
+                if token not in self._vocabulary:
+                    self._vocabulary[token] = len(self._vocabulary)
+
+        vectors: list[list[float]] = []
+        size = len(self._vocabulary)
+        for text in texts:
+            vector = [0.0] * size
+            counts = Counter(_tokenize(text))
+            for token, count in counts.items():
+                vector[self._vocabulary[token]] = float(count)
+            vectors.append(vector)
+        return vectors
+
+
+class InMemoryVectorStore:
+    """Naive cosine-similarity store for reference retrieval workflows."""
+
+    def __init__(self) -> None:
+        self._chunks: list[IndexedChunk] = []
+
+    def upsert(self, chunks: list[IndexedChunk]) -> None:
+        by_id = {chunk.id: chunk for chunk in self._chunks}
+        for chunk in chunks:
+            by_id[chunk.id] = chunk
+        self._chunks = list(by_id.values())
+
+    def search(self, query_embedding: list[float], top_k: int) -> list[SearchResult]:
+        scored = [
+            SearchResult(
+                chunk=Chunk(
+                    id=chunk.id,
+                    document_id=chunk.document_id,
+                    text=chunk.text,
+                    metadata=dict(chunk.metadata),
+                ),
+                score=_cosine_similarity(query_embedding, chunk.embedding),
+            )
+            for chunk in self._chunks
+        ]
+        scored.sort(key=lambda result: result.score, reverse=True)
+        return scored[:top_k]
+
+
+@dataclass(slots=True)
+class RetrievalResponse:
+    query: str
+    results: list[SearchResult]
+
+
+class InMemoryRAGPipeline:
+    """Reference RAG pipeline that keeps indexing and retrieval interfaces separate."""
+
+    def __init__(
+        self,
+        *,
+        chunker: Chunker | None = None,
+        embedder: Embedder | None = None,
+        vector_store: VectorStore | None = None,
+    ) -> None:
+        self.chunker = chunker or SimpleWordChunker()
+        self.embedder = embedder or BagOfWordsEmbedder()
+        self.vector_store = vector_store or InMemoryVectorStore()
+
+    def index_documents(self, documents: list[Document]) -> list[IndexedChunk]:
+        chunks: list[Chunk] = []
+        for document in documents:
+            chunks.extend(self.chunker.chunk(document))
+
+        embeddings = self.embedder.embed([chunk.text for chunk in chunks]) if chunks else []
+        indexed = [
+            IndexedChunk(
+                id=chunk.id,
+                document_id=chunk.document_id,
+                text=chunk.text,
+                metadata=dict(chunk.metadata),
+                embedding=embedding,
+            )
+            for chunk, embedding in zip(chunks, embeddings, strict=True)
+        ]
+        self.vector_store.upsert(indexed)
+        return indexed
+
+    def retrieve(self, query: str, top_k: int = 5) -> RetrievalResponse:
+        query_embedding = self.embedder.embed([query])[0]
+        return RetrievalResponse(query=query, results=self.vector_store.search(query_embedding, top_k))
+
+
+def _cosine_similarity(left: list[float], right: list[float]) -> float:
+    size = max(len(left), len(right))
+    if size == 0:
+        return 0.0
+
+    padded_left = left + [0.0] * (size - len(left))
+    padded_right = right + [0.0] * (size - len(right))
+
+    numerator = sum(a * b for a, b in zip(padded_left, padded_right, strict=True))
+    left_norm = math.sqrt(sum(a * a for a in padded_left))
+    right_norm = math.sqrt(sum(b * b for b in padded_right))
+    if left_norm == 0.0 or right_norm == 0.0:
+        return 0.0
+    return numerator / (left_norm * right_norm)

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,0 +1,54 @@
+from agentrag import Document, InMemoryRAGPipeline
+from agentrag.pipeline import BagOfWordsEmbedder, SimpleWordChunker
+
+
+def test_index_documents_creates_chunked_reference_pipeline():
+    pipeline = InMemoryRAGPipeline(chunker=SimpleWordChunker(chunk_size=4, overlap=1))
+
+    indexed = pipeline.index_documents(
+        [
+            Document(
+                id="doc-1",
+                text="Ganapathi homam supports obstacle removal and auspicious beginnings for devotees.",
+                metadata={"source": "ritual-guide"},
+            )
+        ]
+    )
+
+    assert len(indexed) >= 2
+    assert indexed[0].document_id == "doc-1"
+    assert indexed[0].metadata["source"] == "ritual-guide"
+    assert indexed[0].embedding
+
+
+def test_retrieve_returns_relevant_chunks_from_in_memory_store():
+    pipeline = InMemoryRAGPipeline()
+    pipeline.index_documents(
+        [
+            Document(
+                id="doc-1",
+                text="Ganapathi homam is performed before major life events to remove obstacles.",
+            ),
+            Document(
+                id="doc-2",
+                text="Satyanarayana vratam centers on gratitude, devotion, and family blessings.",
+            ),
+        ]
+    )
+
+    response = pipeline.retrieve("Which ritual helps remove obstacles?", top_k=1)
+
+    assert response.query == "Which ritual helps remove obstacles?"
+    assert len(response.results) == 1
+    assert response.results[0].chunk.document_id == "doc-1"
+    assert response.results[0].score > 0
+
+
+def test_embedder_grows_vocabulary_without_breaking_previous_vectors():
+    embedder = BagOfWordsEmbedder()
+    first = embedder.embed(["alpha beta"])[0]
+    second = embedder.embed(["beta gamma"])[0]
+
+    assert len(second) >= len(first)
+    assert first[0] > 0
+    assert second[1] > 0


### PR DESCRIPTION
## Summary
- add the first AgentRAG Python package scaffold
- define core RAG pipeline interfaces and shared models
- add a working in-memory indexing and retrieval pipeline with tests

## Testing
- python3 -m py_compile src/agentrag/__init__.py src/agentrag/interfaces.py src/agentrag/pipeline.py tests/test_pipeline.py
- python3 -m pytest tests/test_pipeline.py

Closes #2
Closes #3