### PR TITLE
chore: repo hardening round 2 (Dependabot config)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5


### PR DESCRIPTION
Adds a `.github/dependabot.yml` enabling weekly Dependabot updates for the `pip` ecosystem (pyproject.toml) and `github-actions` (workflows), each with an open-PR limit of 5.

This is purely additive and non-breaking: it introduces a new config file and does not modify any existing files or code.